### PR TITLE
Fill mode fleshed out

### DIFF
--- a/crwBook.py
+++ b/crwBook.py
@@ -81,6 +81,15 @@ class Book(object):
                             f[1],
                             UNKNOWN)))
 
+    def display_unknowns(self, **kwargs):
+        '''
+        Display the unknown fields in a book
+        '''
+
+        for f in bkFields:
+            if getattr(self, f[0]) == UNKNOWN:
+                print(f[0])
+
     @property
     def has_unknowns(self):
         for f in bkFields:

--- a/crwISBNSearch.py
+++ b/crwISBNSearch.py
@@ -163,6 +163,18 @@ class OpenLibraryOrg(BaseSearcher):
                         'publish_date',
                         crwBook.UNKNOWN)
 
+                    # Get the identifiers
+                    if 'identifiers' in book_info[k1]:
+                        for i in book_info[k1]['identifiers']['isbn_10']:
+                            book.isbn10 = i
+                        for i in book_info[k1]['identifiers']['isbn_13']:
+                            book.isbn13 = i
+                        try: 
+                            for i in book_info[k1]['identifiers']['lccn']:
+                                book.lccn = i
+                        except KeyError:
+                            pass
+
             else:
                 print ("\tNo openlibrary.org data")
 

--- a/my_library.py
+++ b/my_library.py
@@ -138,6 +138,7 @@ http://www.apache.org/licenses/LICENSE-2.0""".format(
 
         def find_book(mode, value):
 
+            fill = args.fill
             # Create an empty book
             book = crwBook.Book(isbn=value)
 
@@ -151,10 +152,21 @@ http://www.apache.org/licenses/LICENSE-2.0""".format(
                 # will unconditionally overwrite known fields.
                 book = searcher.search(isbn=value, mode=mode, book=book)
 
-                if book.author != crwBook.UNKNOWN:
+                if book.has_unknowns:
+                    print("No data for ")
+                    book.display_unknowns()
+
+                if book.author != crwBook.UNKNOWN and fill == False:
                     break
+                elif book.has_unknowns and fill:
+                    print("Attempting to fill unknown values...")
                 else:
                     print('\tNot found')
+
+            # if book.has_unknowns:
+            #     for f in book:
+            #         if getattr(self, f[0]) == UNKNOWN:
+            #             print(f[0])
 
             library.add_book(book)
             print(book)
@@ -172,7 +184,7 @@ http://www.apache.org/licenses/LICENSE-2.0""".format(
                 print("Searching by {}".format(mode.name))
             elif isbn == 'lccn' or isbn == 'c':
                 mode = Modes.LCCN
-                print('(WIP) - Searching by {}'.format(mode.name))
+                print('Searching by {}'.format(mode.name))
             else:
                 exists, book = library.isbn_exists(isbn)
                 if exists:


### PR DESCRIPTION
Did some work to flesh out the fill mode from issue #15 - There might be a better way to do this, but it was working for me. This also includes pulling in the identifier (ISBN 10, 13, and LCCN) from Open Library which will help with issue #13 as well.

I added a display_unknowns function to the book class, which will show what's missing when you do a search. it might not be necessary forever, but it was useful in debugging this at least! 